### PR TITLE
Fixes #43 | Added python3 changes to Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,8 @@ services:
     volumes:
       - ./app:/data/app
     command:
-      bash -c "python /data/app/main.py"
+      python -m app.main
+    tty: true
   snake2:
     image: hirethissnake
     ports:
@@ -15,7 +16,8 @@ services:
     volumes:
       - ./app:/data/app
     command:
-      bash -c "python /data/app/main.py"
+      python -m app.main
+    tty: true
   snake3:
     image: hirethissnake
     ports:
@@ -23,4 +25,5 @@ services:
     volumes:
       - ./app:/data/app
     command:
-      bash -c "python /data/app/main.py"
+      python -m app.main
+    tty: true


### PR DESCRIPTION
Very minor fix to enable Docker Compose to work with the new Python3 standard.